### PR TITLE
Hijack ringpop lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ Sevnup.prototype.attachToRing = function attachToRing(hashRing) {
     hashRing.lookup = function(key) {
         var vnode = sevnup.getVNodeForKey(key);
         var node = keyLookup(vnode);
-        if ( sevnup.hashring.whoami() == node ) {
+        if ( sevnup.hashring.whoami() === node ) {
             sevnup.addKeyToVNode(vnode, key);
         }
         return node;


### PR DESCRIPTION
This wraps the lookup function with logic to take ownership of a key, and lookup by vnode instead of the key directly

@jwolski take a look at this when you can, as it seems a little slippery to me.
