### PR TITLE
Deal with ringpop already being ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,10 +33,7 @@ function Sevnup(params) {
 
 Sevnup.prototype._attachToRing = function _attachToRing() {
     var self = this;
-    this.hashRing.on('ready', function() {
-        self.hashRing.on('changed', self._onRingStateChange.bind(self));
-        self._onRingStateChange();
-    });
+
     this.hashRing.lookup = function sevnupLookup(key) {
         var vnode = self._getVNodeForKey(key);
         var node = self.hashRingLookup(vnode);
@@ -53,6 +50,17 @@ Sevnup.prototype._attachToRing = function _attachToRing() {
         }
         return node;
     };
+
+    if (this.hashRing.isReady) {
+        onReady();
+    } else {
+        this.hashRing.on('ready', onReady);
+    }
+
+    function onReady() {
+        self.hashRing.on('changed', self._onRingStateChange.bind(self));
+        self._onRingStateChange();
+    }
 };
 
 /**

--- a/mock_ring.js
+++ b/mock_ring.js
@@ -7,10 +7,12 @@ function MockRing(me) {
     EventEmitter.call(this);
     this.keyMapping = {};
     this.me = me;
+    this.isReady = false;
 }
 util.inherits(MockRing, EventEmitter);
 
 MockRing.prototype.ready = function ready() {
+    this.isReady = true;
     this.emit('ready');
 };
 

--- a/test/sevnup.js
+++ b/test/sevnup.js
@@ -16,7 +16,7 @@ function createSevnup(params) {
     return sevnup;
 }
 
-test('Sevnup initial recovery, then recovery and release as ring state changes', function(assert) {
+function sevnupFlow(assert, earlyReady) {
     var ring = new MockRing('A');
     ring.changeRing({
         0: 'A',
@@ -42,13 +42,20 @@ test('Sevnup initial recovery, then recovery and release as ring state changes',
         done();
     }
 
+    if (earlyReady) {
+        ring.ready();
+    }
+
     createSevnup({
         store: store,
         ring: ring,
         recover: recover,
         release: release
     });
-    ring.ready();
+
+    if  (!earlyReady) {
+        ring.ready();
+    }
     setTimeout(checkRecovery, 100);
 
     function checkRecovery() {
@@ -77,6 +84,14 @@ test('Sevnup initial recovery, then recovery and release as ring state changes',
         assert.deepEqual(store.loadKeys(2), ['k4']);
         assert.end();
     }
+}
+
+test('Sevnup initial recovery, then recovery and release as ring state changes - late ready', function(assert) {
+    sevnupFlow(assert, false);
+});
+
+test('Sevnup initial recovery, then recovery and release as ring state changes - early ready', function(assert) {
+    sevnupFlow(assert, true);
 });
 
 test('Sevnup attached lookup persists owned key', function(assert) {


### PR DESCRIPTION
Turns out ringpop can be ready before sevnup is initialized.
Deal with either situation.