### PR TITLE
Wait for ring state to stabilize

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,3 +208,7 @@ Sevnup.prototype.workCompleteOnKey = function workCompleteOnKey(key, done) {
 Sevnup.prototype._getVNodeForKey = function _getVNodeForKey(key) {
     return farmhash.hash32(key) % this.totalVNodes;
 };
+
+Sevnup.prototype.destroy = function destroy() {
+    clearTimeout(this.calmTimeout);
+};

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ var async = require('async');
 var CacheStore = require('./cache_store');
 
 var DEFAULT_TOTAL_VNODES = 1024;
-var DEFAULT_CALM_THRESHOLD = 1000;
+var DEFAULT_CALM_THRESHOLD = 500;
 var MAX_PARALLEL_TASKS = 10;
 
 /**

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var async = require('async');
 var CacheStore = require('./cache_store');
 
 var DEFAULT_TOTAL_VNODES = 1024;
+var DEFAULT_CALM_THRESHOLD = 1000;
 var MAX_PARALLEL_TASKS = 10;
 
 /**
@@ -25,6 +26,8 @@ function Sevnup(params) {
     this.releaseKeyCallback = params.releaseKey;
     this.totalVNodes = params.totalVNodes || DEFAULT_TOTAL_VNODES;
     this.logger = params.logger;
+    this.calmThreshold = params.calmThreshold || DEFAULT_CALM_THRESHOLD;
+    this.calmTimeout = null;
 
     this.ownedVNodes = [];
 
@@ -90,24 +93,30 @@ Sevnup.prototype._getOwnedVNodes = function _getOwnedVNodes() {
  */
 Sevnup.prototype._onRingStateChange = function _onRingStateChange() {
     var self = this;
+    if (this.calmTimeout) {
+        clearTimeout(this.calmTimeout);
+    }
+    this.calmTimeout = setTimeout(execute, this.calmThreshold);
 
-    var oldOwnedVNodes = this.ownedVNodes;
-    var newOwnedVNodes = this.ownedVNodes = this._getOwnedVNodes();
+    function execute() {
+        var oldOwnedVNodes = self.ownedVNodes;
+        var newOwnedVNodes = self.ownedVNodes = self._getOwnedVNodes();
 
-    var nodesToRelease = _.difference(oldOwnedVNodes, newOwnedVNodes);
-    var nodesToRecover = _.difference(newOwnedVNodes, oldOwnedVNodes);
+        var nodesToRelease = _.difference(oldOwnedVNodes, newOwnedVNodes);
+        var nodesToRecover = _.difference(newOwnedVNodes, oldOwnedVNodes);
 
-    this.logger.info('Sevnup._onRingStateChange', {
-        releasing: nodesToRelease,
-        recovering: nodesToRecover
-    });
+        self.logger.info('Sevnup._onRingStateChange', {
+            releasing: nodesToRelease,
+            recovering: nodesToRecover
+        });
 
-    async.parallel([
-        this._forEachKeyInVNodes.bind(this, nodesToRelease, this._releaseKey.bind(this)),
-        this._forEachKeyInVNodes.bind(this, nodesToRecover, this._recoverKey.bind(this))
-    ], function() {
-        nodesToRelease.forEach(self.store.releaseFromCache.bind(self.store));
-    });
+        async.parallel([
+            self._forEachKeyInVNodes.bind(self, nodesToRelease, self._releaseKey.bind(self)),
+            self._forEachKeyInVNodes.bind(self, nodesToRecover, self._recoverKey.bind(self))
+        ], function() {
+            nodesToRelease.forEach(self.store.releaseFromCache.bind(self.store));
+        });
+    }
 };
 
 Sevnup.prototype._forEachKeyInVNodes = function _forEachKeyInVNodes(vnodes, onKey, done) {

--- a/test/sevnup.js
+++ b/test/sevnup.js
@@ -330,3 +330,36 @@ test('Sevnup._onRingStateChange waits for calm before processing ring state chan
         assert.end();
     }
 });
+
+test('Sevnup.destroy stops timers', function(assert) {
+    var ring = new MockRing('A');
+    ring.changeRing({
+        0: 'A'
+    });
+    var store = new MockStore();
+    store.addKey(0, 'k1');
+
+    var sevnup = createSevnup({
+        store: store,
+        ring: ring,
+        totalVNodes: 1,
+        recover: function() {
+            assert.fail();
+        },
+        release: function() {
+            assert.fail();
+        },
+        logger: {
+            info: function() {
+                assert.fail();
+            }
+        },
+        calmThreshold: 200
+    });
+    ring.ready();
+    sevnup.destroy();
+    setTimeout(checkResults, 300);
+    function checkResults() {
+        assert.end();
+    }
+});

--- a/test/sevnup.js
+++ b/test/sevnup.js
@@ -11,10 +11,22 @@ function createSevnup(params) {
         recoverKey: params.recover,
         releaseKey: params.release,
         logger: params.logger || console,
-        totalVNodes: params.totalVNodes
+        totalVNodes: params.totalVNodes,
+        calmThreshold: 1 || params.calmThreshold
     });
     return sevnup;
 }
+
+test('Sevnup default params', function(assert) {
+    var ring = new MockRing('A');
+    var sevnup = new Sevnup({
+        hashRing: ring,
+        store: {}
+    });
+    assert.ok(sevnup.calmThreshold);
+    assert.ok(sevnup.totalVNodes);
+    assert.end();
+});
 
 function sevnupFlow(assert, earlyReady) {
     var ring = new MockRing('A');
@@ -259,4 +271,62 @@ test('Sevnup.workCompleteOnKey removes key from vnode', function(assert) {
         assert.deepEqual(store.loadKeys(0), ['k2']);
         assert.end();
     });
+});
+
+test('Sevnup._onRingStateChange waits for calm before processing ring state change', function(assert) {
+    var ring = new MockRing('A');
+    ring.changeRing({
+        0: 'A'
+    });
+    var store = new MockStore();
+    store.addKey(0, 'k1');
+
+    var recovers = 0;
+    var releases = 0;
+    var logs = 0;
+    createSevnup({
+        store: store,
+        ring: ring,
+        totalVNodes: 1,
+        recover: function(key, done) {
+            recovers++;
+            done(null, false);
+        },
+        release: function(key, done) {
+            releases++;
+            done();
+        },
+        logger: {
+            info: function() {
+                logs++;
+            }
+        },
+        calmThreshold: 200
+    });
+    ring.ready();
+    ring.changeRing({
+        0: 'B'
+    });
+    ring.changeRing({
+        0: 'A'
+    });
+    ring.changeRing({
+        0: 'B'
+    });
+    ring.changeRing({
+        0: 'A'
+    });
+    ring.changeRing({
+        0: 'B'
+    });
+    ring.changeRing({
+        0: 'A'
+    });
+    setTimeout(checkResults, 300);
+    function checkResults() {
+        assert.equal(recovers, 1);
+        assert.equal(releases, 0);
+        assert.equal(logs, 1);
+        assert.end();
+    }
 });


### PR DESCRIPTION
I noticed in production that there was a lot of ring state thrash on startup.
This makes it wait some time after the last ring state change before doing recover/release.