### PR TITLE
only let one recover/release process run at a time

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,6 +132,10 @@ Sevnup.prototype._getOwnedVNodes = function _getOwnedVNodes() {
 
 Sevnup.prototype._onRingStateChange = function _onRingStateChange() {
     var self = this;
+    if (this.stateChangeQueue.length() > 0) {
+        // Ring change already queued
+        return;
+    }
     if (this.calmTimeout) {
         clearTimeout(this.calmTimeout);
     }


### PR DESCRIPTION
Recoveries can take a long time, you'll get in trouble if two ring changes happen close to one another.

@charliezhang @proflayton 