### PR TITLE
Watch Mode

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ function Sevnup(params) {
     this.logger = params.logger;
     this.calmThreshold = params.calmThreshold || DEFAULT_CALM_THRESHOLD;
     this.calmTimeout = null;
+    this.watchMode = params.watchMode;
 
     this.ownedVNodes = [];
 
@@ -89,14 +90,16 @@ Sevnup.prototype.getOwnedKeys = function getOwnedKeys(done) {
 Sevnup.prototype._attachToRing = function _attachToRing(addOnLookup) {
     var self = this;
 
-    this.hashRing.lookup = function sevnupLookup(key) {
-        var vnode = self._getVNodeForKey(key);
-        var node = self.hashRingLookup(vnode);
-        if (addOnLookup) {
-            self.addKey(key);
-        }
-        return node;
-    };
+    if (!this.watchMode) {
+        this.hashRing.lookup = function sevnupLookup(key) {
+            var vnode = self._getVNodeForKey(key);
+            var node = self.hashRingLookup(vnode);
+            if (addOnLookup) {
+                self.addKey(key);
+            }
+            return node;
+        };
+    }
 
     if (this.hashRing.isReady) {
         onReady();

--- a/test/sevnup.js
+++ b/test/sevnup.js
@@ -29,6 +29,19 @@ test('Sevnup default params', function(assert) {
     assert.end();
 });
 
+test('Sevnup watch mode', function(assert) {
+    var ring = new MockRing('A');
+    var sevnup = new Sevnup({
+        hashRing: ring,
+        store: {},
+        watchMode: true
+    });
+    assert.ok(sevnup.calmThreshold);
+    assert.ok(sevnup.totalVNodes);
+    assert.deepEqual(sevnup.hashRing.lookup, MockRing.prototype.lookup, 'Lookup didn\'t change');
+    assert.end();
+});
+
 function sevnupFlow(assert, earlyReady) {
     var ring = new MockRing('A');
     ring.changeRing({


### PR DESCRIPTION
Allow the option to prevent ringpop client mutation. This is necessary in my usecase where I need to create a sevnup interface that customizes how vnode lookups are done.