### PR TITLE
upgrade farmhash@1.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -260,7 +260,7 @@ Sevnup.prototype._releaseKey = function _releaseKey(vnode, key, done) {
  * @param {string} key The key to match to a vnode.
  */
 Sevnup.prototype.getVNodeForKey = function getVNodeForKey(key) {
-    return farmhash.hash32(key) % this.totalVNodes;
+    return farmhash.hash32v1(key) % this.totalVNodes;
 };
 
 Sevnup.prototype.destroy = function destroy() {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "farmhash": "^0.2.2",
+    "farmhash": "^1.2.0",
     "lodash": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This enables node4 combatibility,

Since it's a major bump we have to change the `hash32`
method to `hash32v1`, the new `hash32` method is basically
`hash32v2` and has different behaviour.

r: @iproctor @proflayton