### PR TITLE
Retry mechanism for recover/release/ringchange

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -28,6 +28,7 @@
         "clearTimeout": true,
         "setInterval": true,
         "clearInterval": true,
+        "setImmediate": true,
         "require": false,
         "module": false,
         "exports": true,

--- a/index.js
+++ b/index.js
@@ -236,7 +236,10 @@ Sevnup.prototype._withRetry = function _withRetry(retryName, fn, done) {
             self.maybeIncrementStat('sevnup.retrying', {
                 type: retryName
             });
-            setTimeout(self._withRetry.bind(self, retryName, fn, done), self.retryIntervalMs);
+            setTimeout(
+                self._withRetry.bind(self, retryName, fn, done),
+                self.retryIntervalMs
+            ).unref();
             return;
         }
         done.apply(done, arguments);

--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ var CacheStore = require('./cache_store');
 
 var DEFAULT_TOTAL_VNODES = 1024;
 var DEFAULT_CALM_THRESHOLD = 500;
+var DEFAULT_RETRY_INTERVAL_MS = 5000;
 var MAX_PARALLEL_TASKS = 10;
 
 /**
@@ -33,6 +34,8 @@ function Sevnup(params) {
     this.calmTimeout = null;
     this.watchMode = params.watchMode;
     this.running = true;
+    this.retryIntervalMs = params.retryIntervalMs || DEFAULT_RETRY_INTERVAL_MS;
+    this.retryRecoverOnFailure = params.retryRecoverOnFailure || false;
 
     this.ownedVNodes = [];
 
@@ -179,29 +182,61 @@ Sevnup.prototype._handleRingStateChange = function _handleRingStateChange(arg, d
     });
 
     async.parallel([
-        self._forEachKeyInVNodes.bind(self, nodesToRelease, self._releaseKey.bind(self)),
-        self._forEachKeyInVNodes.bind(self, nodesToRecover, self._recoverKey.bind(self))
+        self._forEachKeyInVNodesWithRetry.bind(self, self.retryRecoverOnFailure, nodesToRelease, self._releaseKey.bind(self)),
+        self._forEachKeyInVNodesWithRetry.bind(self, self.retryRecoverOnFailure, nodesToRecover, self._recoverKey.bind(self))
     ], function() {
         nodesToRelease.forEach(self.store.releaseFromCache.bind(self.store));
         done();
     });
 };
 
-Sevnup.prototype._forEachKeyInVNodes = function _forEachKeyInVNodes(vnodes, onKey, done) {
+Sevnup.prototype._forEachKeyInVNodesWithRetry = function _forEachKeyInVNodesWithRetry(retryErrors, vnodes, onKey, done) {
     var self = this;
 
     async.eachSeries(vnodes, onVNode, done);
 
     function onVNode(vnode, next) {
         async.waterfall([
-            self.store.loadKeys.bind(self.store, vnode),
+            function _loadWithRetries(wNext) {
+                maybeWithRetry(self.store.loadKeys.bind(self.store, vnode), wNext);
+            },
             onKeys.bind(null, vnode),
         ], next);
     }
 
     function onKeys(vnode, keys, next) {
-        async.eachLimit(keys, MAX_PARALLEL_TASKS, onKey.bind(null, vnode), next);
+        async.eachLimit(keys, MAX_PARALLEL_TASKS, function _try(key, eNext) {
+            maybeWithRetry(function _try(cb) {
+                onKey(vnode, key, cb);
+            }, eNext);
+        }, next);
     }
+
+    function maybeWithRetry(fn, cb) {
+        if (retryErrors) {
+            self._withRetry(fn, cb);
+        } else {
+            fn(function _noRetry() {
+                // Ignore errors
+                cb.apply(cb, [null].concat(Array.prototype.slice.call(arguments, 1)));
+            });
+        }
+    }
+};
+
+Sevnup.prototype._forEachKeyInVNodes = function _forEachKeyInVNodes(vnodes, onKey, done) {
+    this._forEachKeyInVNodesWithRetry(false, vnodes, onKey, done);
+};
+
+Sevnup.prototype._withRetry = function _withRetry(fn, done) {
+    var self = this;
+    fn(function _checkError(err) {
+        if (err) {
+            setTimeout(self._withRetry.bind(self, fn, done), self.retryIntervalMs);
+            return;
+        }
+        done.apply(done, arguments);
+    });
 };
 
 Sevnup.prototype._recoverKey = function _recoverKey(vnode, key, done) {
@@ -234,8 +269,8 @@ Sevnup.prototype._recoverKey = function _recoverKey(vnode, key, done) {
                 error: err
             });
         }
-        // Swallow
-        done();
+        // We should propogate errors so we can properly retry if we have that setup
+        done(err);
     });
 };
 
@@ -249,8 +284,8 @@ Sevnup.prototype._releaseKey = function _releaseKey(vnode, key, done) {
                 error: err
             });
         }
-        // Swallow
-        done();
+        // We should propogate errors so we can properly retry if we have that setup
+        done(err);
     });
 };
 

--- a/test/sevnup.js
+++ b/test/sevnup.js
@@ -164,6 +164,8 @@ test('Sevnup _withRetry stats failures', function(assert) {
         retryRecoverOnFailure: true
     });
     var error = true;
+    // Hold the process to ensure the unrefed timeout in the retry function executes
+    var t = setTimeout(function _noop(){}, 1000);
     sevnup._withRetry('retryPlease', function _cb(cb) {
         if (error) {
             error = false;
@@ -179,6 +181,7 @@ test('Sevnup _withRetry stats failures', function(assert) {
                 }
             }
         }]);
+        clearTimeout(t);
         assert.end();
     });
 });


### PR DESCRIPTION
We need a retry mechanism in place to ensure eventual recover of state.
Caveat, this will hold ring changes in the queue until a success occurs. This seems beneficial to me, albeit different from current design, because it ensures consistency.

@iproctor @Raynos 